### PR TITLE
Add module-info and refresh for Java 20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <name>Blake2B</name>
     <groupId>com.rfksystems</groupId>
     <artifactId>blake2b</artifactId>
-    <version>1.0.0</version>
+    <version>2.0.0</version>
     <packaging>jar</packaging>
 
     <url>https://github.com/rfksystems/blake2b</url>
@@ -35,6 +35,14 @@
         </developer>
     </developers>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <java.version>20</java.version>
+        <maven.compiler.source>20</maven.compiler.source>
+        <maven.compiler.target>20</maven.compiler.target>
+    </properties>
+
     <scm>
         <connection>scm:git:git://github.com/rfksystems/blake2b.git</connection>
         <developerConnection>scm:git:ssh://github.com:rfksystems/blake2b.git</developerConnection>
@@ -45,19 +53,19 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.10</version>
+            <version>1.16.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>RELEASE</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.2</version>
+            <version>2.10</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -73,16 +81,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.11.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>9</source>
+                    <target>9</target>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -126,6 +134,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>empty-javadoc-jar</id>

--- a/src/main/java/com/rfksystems/blake2b/security/Blake2bProvider.java
+++ b/src/main/java/com/rfksystems/blake2b/security/Blake2bProvider.java
@@ -4,7 +4,7 @@ import java.security.Provider;
 
 public class Blake2bProvider extends Provider {
     public Blake2bProvider() {
-        super("BLAKE2B", 1.0, "BLAKE2B provider");
+        super("BLAKE2B", "1.0", "BLAKE2B provider");
 
         put("MessageDigest.BLAKE2B-160", Blake2b160Digest.class.getName());
         put("MessageDigest.BLAKE2B-256", Blake2b256Digest.class.getName());

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,4 @@
+module com.rfksystems.blake2b {
+    exports com.rfksystems.blake2b;
+    exports com.rfksystems.blake2b.security;
+}


### PR DESCRIPTION
Dear @rfksystems and @Addvilz,

Could you please accept those changes and push it to Maven Central? We'd require this updated package as a result of some works being done in Crypt4GH, genomics sequencing a cryptographic library being worked on mainly by @kjetilkl on https://github.com/uio-bmi/crypt4gh/issues/85#issuecomment-1804468714

I've bumped this library to 2.0.0 directly as it might be a breaking change, so I hope I'm following semver here... please do let me know if additional corrections are needed.

Thanks in advance! 